### PR TITLE
fix: Run CI on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
This PR updates the CI workflow to also run on pushes to the main branch, ensuring the main branch is always tested.