### PR TITLE
feat: Create Score data model

### DIFF
--- a/Mumi/Models/Score.swift
+++ b/Mumi/Models/Score.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct Score: Identifiable {
+    let id: UUID
+    let filename: String
+    let url: URL
+}


### PR DESCRIPTION
This PR introduces the `Score` data model, which will be used to represent a single PDF score in the application. Closes #4