### PR TITLE
feat(theme): Implement Classic Parchment color theme (Option 1)

### DIFF
--- a/Mumi/Assets.xcassets/Accent.colorset/Contents.json
+++ b/Mumi/Assets.xcassets/Accent.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0x80",
+          "green" : "0x00",
+          "blue" : "0x20",
+          "alpha" : "1.000"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0xA3",
+          "green" : "0x2D",
+          "blue" : "0x4F",
+          "alpha" : "1.000"
+        }
+      }
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Mumi/Assets.xcassets/Background.colorset/Contents.json
+++ b/Mumi/Assets.xcassets/Background.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0xF7",
+          "green" : "0xF5",
+          "blue" : "0xF2",
+          "alpha" : "1.000"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0x1C",
+          "green" : "0x1C",
+          "blue" : "0x1E",
+          "alpha" : "1.000"
+        }
+      }
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Mumi/Assets.xcassets/Text.colorset/Contents.json
+++ b/Mumi/Assets.xcassets/Text.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0x4E",
+          "green" : "0x44",
+          "blue" : "0x3C",
+          "alpha" : "1.000"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0xEF",
+          "green" : "0xEB",
+          "blue" : "0xE6",
+          "alpha" : "1.000"
+        }
+      }
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Mumi/ContentView.swift
+++ b/Mumi/ContentView.swift
@@ -37,6 +37,7 @@ struct ScoreLibraryView: View {
                 .padding()
             }
         }
+        .background(Color.Theme.background)
         .onAppear {
             viewModel.loadScores()
         }

--- a/Mumi/Theme/Color+Theme.swift
+++ b/Mumi/Theme/Color+Theme.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+extension Color {
+    struct Theme {
+        static var background: Color {
+            Color("Background")
+        }
+        static var text: Color {
+            Color("Text")
+        }
+        static var accent: Color {
+            Color("Accent")
+        }
+    }
+}

--- a/Mumi/Views/HeaderView.swift
+++ b/Mumi/Views/HeaderView.swift
@@ -8,10 +8,12 @@ struct HeaderView: View {
             Text("My Scores")
                 .font(.largeTitle)
                 .fontWeight(.bold)
+                .foregroundColor(Color.Theme.text)
             Spacer()
             Button(action: onAdd) {
                 Image(systemName: "plus")
                     .font(.largeTitle)
+                    .foregroundColor(Color.Theme.accent)
             }
         }
         .padding()

--- a/Mumi/Views/ScoreThumbnailView.swift
+++ b/Mumi/Views/ScoreThumbnailView.swift
@@ -14,10 +14,12 @@ struct ScoreThumbnailView: View {
             } else {
                 Image(systemName: "doc.text.image")
                     .font(.largeTitle)
+                    .foregroundColor(Color.Theme.text.opacity(0.5))
                     .frame(width: 150, height: 200)
             }
             Text(score.filename)
                 .font(.caption)
+                .foregroundColor(Color.Theme.text)
         }
         .onAppear {
             DispatchQueue.global(qos: .userInitiated).async {


### PR DESCRIPTION
This PR implements the "Classic Parchment" color theme, as described in issue #19. This includes creating a new color system and applying it to the existing views. Closes #19