### PR TITLE
feat: Implement Score Detail View

### DIFF
--- a/Mumi/ContentView.swift
+++ b/Mumi/ContentView.swift
@@ -60,6 +60,7 @@ struct ScoreLibraryView: View {
             }
             .navigationBarHidden(true)
         }
+        .navigationViewStyle(.stack)
     }
 }
 

--- a/Mumi/ContentView.swift
+++ b/Mumi/ContentView.swift
@@ -16,15 +16,19 @@ struct ScoreLibraryView: View {
     ]
 
     var body: some View {
-        VStack {
-            HeaderView(onAdd: {
-                isImporterPresented = true
-            })
+        NavigationView {
+            VStack {
+                HeaderView(onAdd: {
+                    isImporterPresented = true
+                })
 
-            ScrollView {
-                LazyVGrid(columns: columns, spacing: 20) {
-                    ForEach(viewModel.scores) { score in
-                        ScoreThumbnailView(score: score)
+                ScrollView {
+                    LazyVGrid(columns: columns, spacing: 20) {
+                        ForEach(viewModel.scores) { score in
+                            NavigationLink(destination: ScoreDetailView(score: score)) {
+                                ScoreThumbnailView(score: score)
+                            }
+                            .buttonStyle(PlainButtonStyle())
                             .contextMenu {
                                 Button(role: .destructive) {
                                     viewModel.deleteScore(score)
@@ -32,27 +36,29 @@ struct ScoreLibraryView: View {
                                     Label("Delete", systemImage: "trash")
                                 }
                             }
+                        }
                     }
+                    .padding()
                 }
-                .padding()
             }
-        }
-        .background(Color.Theme.background)
-        .onAppear {
-            viewModel.loadScores()
-        }
-        .fileImporter(
-            isPresented: $isImporterPresented,
-            allowedContentTypes: [.pdf]
-        ) { result in
-            switch result {
-            case .success(let url):
-                viewModel.importScore(from: url)
-                isImporterPresented = false
-            case .failure(let error):
-                print("Error importing file: \(error.localizedDescription)")
-                isImporterPresented = false
+            .background(Color.Theme.background)
+            .onAppear {
+                viewModel.loadScores()
             }
+            .fileImporter(
+                isPresented: $isImporterPresented,
+                allowedContentTypes: [.pdf]
+            ) { result in
+                switch result {
+                case .success(let url):
+                    viewModel.importScore(from: url)
+                    isImporterPresented = false
+                case .failure(let error):
+                    print("Error importing file: \(error.localizedDescription)")
+                    isImporterPresented = false
+                }
+            }
+            .navigationBarHidden(true)
         }
     }
 }

--- a/Mumi/Views/PDFKitView.swift
+++ b/Mumi/Views/PDFKitView.swift
@@ -1,0 +1,19 @@
+
+import SwiftUI
+import PDFKit
+
+struct PDFKitView: UIViewRepresentable {
+    let url: URL
+
+    func makeUIView(context: Context) -> PDFView {
+        let pdfView = PDFView()
+        pdfView.document = PDFDocument(url: self.url)
+        pdfView.autoScales = true
+        pdfView.displayMode = .singlePageContinuous
+        return pdfView
+    }
+
+    func updateUIView(_ uiView: PDFView, context: Context) {
+        // We can update the view here if needed.
+    }
+}

--- a/Mumi/Views/ScoreDetailFooterView.swift
+++ b/Mumi/Views/ScoreDetailFooterView.swift
@@ -1,0 +1,40 @@
+
+import SwiftUI
+
+struct ScoreDetailFooterView: View {
+    var onPlay: () -> Void
+    var onStop: () -> Void
+    
+    @State private var tempo: Double = 120
+
+    var body: some View {
+        HStack {
+            Button(action: onPlay) {
+                Image(systemName: "play.fill")
+                    .font(.title)
+                    .foregroundColor(Color.Theme.accent)
+            }
+            
+            Spacer()
+            
+            Button(action: onStop) {
+                Image(systemName: "stop.fill")
+                    .font(.title)
+                    .foregroundColor(Color.Theme.accent)
+            }
+            
+            Spacer()
+
+            HStack {
+                Image(systemName: "metronome")
+                    .font(.title)
+                    .foregroundColor(Color.Theme.text)
+                Text("\(Int(tempo)) BPM")
+                    .font(.body)
+                    .foregroundColor(Color.Theme.text)
+            }
+        }
+        .padding()
+        .background(Color.Theme.surface.edgesIgnoringSafeArea(.bottom))
+    }
+}

--- a/Mumi/Views/ScoreDetailHeaderView.swift
+++ b/Mumi/Views/ScoreDetailHeaderView.swift
@@ -1,0 +1,19 @@
+
+import SwiftUI
+
+struct ScoreDetailHeaderView: View {
+    var onBack: () -> Void
+
+    var body: some View {
+        HStack {
+            Button(action: onBack) {
+                Image(systemName: "chevron.backward")
+                    .font(.title2)
+                    .foregroundColor(Color.Theme.accent)
+            }
+            Spacer()
+        }
+        .padding()
+        .background(Color.Theme.surface.edgesIgnoringSafeArea(.top))
+    }
+}

--- a/Mumi/Views/ScoreDetailView.swift
+++ b/Mumi/Views/ScoreDetailView.swift
@@ -2,11 +2,22 @@
 import SwiftUI
 
 struct ScoreDetailView: View {
+    @Environment(\.presentationMode) var presentationMode
     let score: Score
 
     var body: some View {
-        PDFKitView(url: score.url)
-            .navigationTitle(score.filename)
-            .navigationBarTitleDisplayMode(.inline)
+        VStack(spacing: 0) {
+            ScoreDetailHeaderView(onBack: {
+                self.presentationMode.wrappedValue.dismiss()
+            })
+            PDFKitView(url: score.url)
+            ScoreDetailFooterView(onPlay: {
+                // TODO: Implement play functionality
+            }, onStop: {
+                // TODO: Implement stop functionality
+            })
+        }
+        .navigationBarHidden(true)
+        .navigationBarBackButtonHidden(true)
     }
 }

--- a/Mumi/Views/ScoreDetailView.swift
+++ b/Mumi/Views/ScoreDetailView.swift
@@ -1,0 +1,12 @@
+
+import SwiftUI
+
+struct ScoreDetailView: View {
+    let score: Score
+
+    var body: some View {
+        PDFKitView(url: score.url)
+            .navigationTitle(score.filename)
+            .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,1 +1,1 @@
-feat(score): Implement Score Detail View
+feat(ui): Add header and footer to ScoreDetailView

--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,0 +1,1 @@
+feat(score): Implement Score Detail View


### PR DESCRIPTION
This pull request implements the Score Detail View, allowing users to tap on a score in the library and view it full-screen.

Key changes:
- A new `ScoreDetailView` is created to display the score.
- A `PDFKitView` is used to render the PDF document.
- A custom `ScoreDetailHeaderView` provides a back button.
- A `ScoreDetailFooterView` includes placeholder playback controls.
- The `ScoreLibraryView` now uses a `NavigationLink` to navigate to the detail view.

This closes issue #29.