### PR TITLE
test: Add UI test for score detail navigation

### DIFF
--- a/Mumi.xcodeproj/project.pbxproj
+++ b/Mumi.xcodeproj/project.pbxproj
@@ -29,9 +29,22 @@
 		BE8EA97F2E116D0F00B214A1 /* MumiUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MumiUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		BEB4FCAE2E12612100DA46AC /* Exceptions for "Mumi" folder in "MumiUITests" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				AccessibilityIdentifiers.swift,
+			);
+			target = BE8EA97E2E116D0F00B214A1 /* MumiUITests */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		BE8EA96A2E116D0B00B214A1 /* Mumi */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				BEB4FCAE2E12612100DA46AC /* Exceptions for "Mumi" folder in "MumiUITests" target */,
+			);
 			path = Mumi;
 			sourceTree = "<group>";
 		};

--- a/Mumi.xcodeproj/project.pbxproj
+++ b/Mumi.xcodeproj/project.pbxproj
@@ -37,12 +37,20 @@
 			);
 			target = BE8EA97E2E116D0F00B214A1 /* MumiUITests */;
 		};
+		BEB4FCB02E1261B100DA46AC /* Exceptions for "Mumi" folder in "MumiTests" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				AccessibilityIdentifiers.swift,
+			);
+			target = BE8EA9742E116D0F00B214A1 /* MumiTests */;
+		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		BE8EA96A2E116D0B00B214A1 /* Mumi */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
+				BEB4FCB02E1261B100DA46AC /* Exceptions for "Mumi" folder in "MumiTests" target */,
 				BEB4FCAE2E12612100DA46AC /* Exceptions for "Mumi" folder in "MumiUITests" target */,
 			);
 			path = Mumi;

--- a/Mumi/AccessibilityIdentifiers.swift
+++ b/Mumi/AccessibilityIdentifiers.swift
@@ -1,0 +1,7 @@
+
+import Foundation
+
+struct AccessibilityIdentifiers {
+    static let scoreThumbnailPlaceholder = "scoreThumbnailPlaceholder"
+    static let scoreDetailView = "scoreDetailView"
+}

--- a/Mumi/Services/MockScoreService.swift
+++ b/Mumi/Services/MockScoreService.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+class MockScoreService: ScoreService {
+    override func fetchScores() -> [Score] {
+        let dummyURL = URL(fileURLWithPath: "/dev/null")
+        return [Score(filename: "dummy.pdf", url: dummyURL)]
+    }
+}

--- a/Mumi/ViewModels/ScoreLibraryViewModel.swift
+++ b/Mumi/ViewModels/ScoreLibraryViewModel.swift
@@ -3,7 +3,15 @@ import Foundation
 class ScoreLibraryViewModel: ObservableObject {
     @Published var scores: [Score] = []
 
-    private let scoreService = ScoreService()
+    private let scoreService: ScoreService
+
+    init() {
+        if ProcessInfo.processInfo.arguments.contains("-uiTestMode") {
+            self.scoreService = MockScoreService()
+        } else {
+            self.scoreService = ScoreService()
+        }
+    }
 
     func loadScores() {
         self.scores = scoreService.fetchScores()

--- a/Mumi/Views/ScoreDetailView.swift
+++ b/Mumi/Views/ScoreDetailView.swift
@@ -19,5 +19,6 @@ struct ScoreDetailView: View {
         }
         .navigationBarHidden(true)
         .navigationBarBackButtonHidden(true)
+        .accessibilityIdentifier(AccessibilityIdentifiers.scoreDetailView)
     }
 }

--- a/Mumi/Views/ScoreThumbnailView.swift
+++ b/Mumi/Views/ScoreThumbnailView.swift
@@ -16,6 +16,7 @@ struct ScoreThumbnailView: View {
                     .font(.largeTitle)
                     .foregroundColor(Color.Theme.text.opacity(0.5))
                     .frame(width: 150, height: 200)
+                    .accessibilityIdentifier(AccessibilityIdentifiers.scoreThumbnailPlaceholder)
             }
             Text(score.filename)
                 .font(.caption)

--- a/MumiUITests/ScoreLibraryUITests.swift
+++ b/MumiUITests/ScoreLibraryUITests.swift
@@ -1,0 +1,23 @@
+
+import XCTest
+
+final class ScoreLibraryUITests: XCTestCase {
+
+    let app = XCUIApplication()
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app.launchArguments = ["-uiTestMode"]
+        app.launch()
+    }
+
+    func testTapScoreThumbnailToNavigateToDetailView() throws {
+        let scoreThumbnail = app.images[AccessibilityIdentifiers.scoreThumbnailPlaceholder]
+        XCTAssertTrue(scoreThumbnail.waitForExistence(timeout: 5))
+
+        scoreThumbnail.tap()
+
+        let detailView = app.otherElements[AccessibilityIdentifiers.scoreDetailView]
+        XCTAssertTrue(detailView.waitForExistence(timeout: 5))
+    }
+}

--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,1 +1,0 @@
-feat(ui): Add header and footer to ScoreDetailView


### PR DESCRIPTION
test: Add UI test for score detail navigation

This commit introduces a UI test to verify that tapping a score thumbnail navigates to the score detail view.

Changes include:
- A new UI test case in `ScoreLibraryUITests.swift`.
- A `MockScoreService` to provide dummy data for testing.
- Centralized accessibility identifiers in `AccessibilityIdentifiers.swift`.
- Minor modifications to the `ScoreLibraryViewModel` and relevant views to support testing.